### PR TITLE
chore(ci): test against PHP 7.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+composer.lock
+composer.phar
+.phpunit.result.cache
+/vendor/

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,27 +14,27 @@ matrix:
       dist: trusty
     - php: 7.0
       dist: xenial
-      env: PHPUNIT=5.7
     - php: 7.1
     - php: 7.2
     - php: 7.3
+    - php: 7.4
+      env: COVERAGE=true
+    - php: nightly
+  allow_failures:
+    - php: nightly
 
 install:
+  - php --version
   - composer install
-  - if [[ $PHPUNIT == 5.7 ]]; then composer require "phpunit/phpunit:5.7"; fi
 
 before_script:
   - mkdir -p build/logs
-  - cd tests
 
 script:
-  - |
-    if [[ $PHPUNIT == 5.7 ]]; then
-      ../vendor/bin/phpunit --colors --coverage-clover ../build/logs/clover.xml .
-    else
-      phpunit --colors --coverage-clover ../build/logs/clover.xml .
-    fi
+  - vendor/bin/phpunit --coverage-clover build/logs/clover.xml
 
 after_success:
-  - cd ..
-  - php vendor/bin/coveralls --config .coveralls.yml -v
+  - |
+    if [[ $COVERAGE ]]; then
+      travis_retry php vendor/bin/php-coveralls --config .coveralls.yml -v
+    fi

--- a/FUNDING.yml
+++ b/FUNDING.yml
@@ -1,0 +1,1 @@
+patreon: joshtronic

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2014, 2015, 2016, 2017, 2018, 2019 Josh Sherman
+Copyright (c) 2014, 2015, 2016, 2017, 2018, 2019, 2020 Josh Sherman
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # php-loremipsum
 
-[![Build Status](https://travis-ci.org/joshtronic/php-loremipsum.svg?branch=master)](https://travis-ci.org/joshtronic/php-loremipsum)
-[![Coverage Status](https://coveralls.io/repos/github/joshtronic/php-loremipsum/badge.svg?branch=master)](https://coveralls.io/github/joshtronic/php-loremipsum?branch=master)
-[![Total Downloads](https://poser.pugx.org/joshtronic/php-loremipsum/downloads)](https://packagist.org/packages/joshtronic/php-loremipsum)
+[![License](https://img.shields.io/packagist/l/joshtronic/php-loremipsum?style=for-the-badge)](https://github.com/joshtronic/php-loremipsum/blob/master/LICENSE)
+![PHP Version](https://img.shields.io/packagist/php-v/joshtronic/php-loremipsum?style=for-the-badge)
+[![Build Status](https://img.shields.io/travis/joshtronic/php-loremipsum/master?style=for-the-badge)](https://travis-ci.org/joshtronic/php-loremipsum)
+[![Coverage Status](https://img.shields.io/coveralls/github/joshtronic/php-loremipsum/master?style=for-the-badge)](https://coveralls.io/github/joshtronic/php-loremipsum?branch=master)
+[![Monthly Downloads](https://img.shields.io/packagist/dm/joshtronic/php-loremipsum?style=for-the-badge)](https://packagist.org/packages/joshtronic/php-loremipsum)
 
 Lorem ipsum generator in PHP without dependencies. Compatible with PHP 5.3+.
-
-[![Become a Patron](https://joshtronic.com/images/become-patron.png)](https://www.patreon.com/joshtronic)
 
 ## Installation
 
@@ -105,7 +105,7 @@ Suggestions and bug reports are always welcome, but karma points are earned for
 pull requests.
 
 Unit tests are required for all contributions. You can run the test suite from
-the `tests` directory simply by running `phpunit .`
+the project's root directory simply by running `phpunit`.
 
 ## Credits
 

--- a/composer.json
+++ b/composer.json
@@ -1,31 +1,30 @@
 {
-    "name": "joshtronic/php-loremipsum",
-    "description": "Lorem ipsum generator in PHP without dependencies",
-    "version": "1.0.4",
-    "type": "library",
-    "keywords": [
-        "lorem",
-        "ipsum",
-        "generator"
-    ],
-    "homepage": "https://github.com/joshtronic/php-loremipsum",
-    "license": "MIT",
-    "authors": [
-        {
-            "name": "Josh Sherman",
-            "email": "hello@joshtronic.com",
-            "homepage": "https://joshtronic.com"
-        }
-    ],
-    "require": {
-        "php": ">=5.3.0"
-    },
-    "require-dev": {
-        "satooshi/php-coveralls": "~1.0"
-    },
-    "autoload": {
-        "psr-4": {
-          "joshtronic\\": "src/"
-        }
+  "name": "joshtronic/php-loremipsum",
+  "description": "Lorem ipsum generator in PHP without dependencies",
+  "version": "1.0.5",
+  "type": "library",
+  "keywords": [
+    "lorem",
+    "ipsum",
+    "generator"
+  ],
+  "homepage": "https://github.com/joshtronic/php-loremipsum",
+  "license": "MIT",
+  "authors": [{
+    "name": "Josh Sherman",
+    "email": "hello@joshtronic.com",
+    "homepage": "https://joshtronic.com"
+  }],
+  "require": {
+    "php": ">=5.3"
+  },
+  "require-dev": {
+    "php-coveralls/php-coveralls": ">=1",
+    "phpunit/phpunit": ">=4"
+  },
+  "autoload": {
+    "psr-4": {
+      "joshtronic\\": "src/"
     }
+  }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+  colors="true"
+  convertErrorsToExceptions="true"
+  convertNoticesToExceptions="true"
+  convertWarningsToExceptions="true"
+  failOnRisky="true"
+  stopOnError="true"
+  stopOnFailure="true"
+  stopOnIncomplete="true"
+  verbose="true"
+>
+  <testsuites>
+    <testsuite name="Lorem Ipsum">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+  <filter>
+    <whitelist addUncoveredFilesFromWhitelist="true">
+      <directory>./src</directory>
+    </whitelist>
+  </filter>
+</phpunit>

--- a/src/LoremIpsum.php
+++ b/src/LoremIpsum.php
@@ -9,7 +9,7 @@
  * Redistribution of these files must retain the above copyright notice.
  *
  * @author    Josh Sherman <hello@joshtronic.com>
- * @copyright Copyright 2014, 2015, 2016, 2017, 2018, 2019 Josh Sherman
+ * @copyright Copyright 2014, 2015, 2016, 2017, 2018, 2019, 2020 Josh Sherman
  * @license   http://www.opensource.org/licenses/mit-license.html
  * @link      https://github.com/joshtronic/php-loremipsum
  */

--- a/tests/LoremIpsumTest.php
+++ b/tests/LoremIpsumTest.php
@@ -1,6 +1,5 @@
 <?php
-
-require_once '../src/LoremIpsum.php';
+require_once './src/LoremIpsum.php';
 
 if (
     !class_exists('\PHPUnit_Framework_TestCase')
@@ -11,29 +10,25 @@ if (
 
 class LoremIpsumTest extends PHPUnit_Framework_TestCase
 {
-    private $lipsum;
-
-    public function setUp()
-    {
-        $this->lipsum = new joshtronic\LoremIpsum();
-    }
-
     public function testWord()
     {
-        $this->assertRegExp('/^[a-z]+$/i', $this->lipsum->word());
+        $lipsum = new joshtronic\LoremIpsum();
+        $this->assertRegExp('/^[a-z]+$/i', $lipsum->word());
     }
 
     public function testWords()
     {
+        $lipsum = new joshtronic\LoremIpsum();
         $this->assertRegExp(
             '/^[a-z]+ [a-z]+ [a-z]+$/i',
-            $this->lipsum->words(3)
+            $lipsum->words(3)
         );
     }
 
     public function testWordsArray()
     {
-        $words = $this->lipsum->wordsArray(3);
+        $lipsum = new joshtronic\LoremIpsum();
+        $words = $lipsum->wordsArray(3);
         $this->assertTrue(is_array($words));
         $this->assertCount(3, $words);
 
@@ -44,22 +39,29 @@ class LoremIpsumTest extends PHPUnit_Framework_TestCase
 
     public function testWordsExceedingVocab()
     {
-        $this->assertCount(500, $this->lipsum->wordsArray(500));
+        $lipsum = new joshtronic\LoremIpsum();
+        $this->assertCount(500, $lipsum->wordsArray(500));
     }
 
     public function testSentence()
     {
-        $this->assertRegExp('/^[a-z, ]+\.$/i', $this->lipsum->sentence());
+        $lipsum = new joshtronic\LoremIpsum();
+        $this->assertRegExp('/^[a-z, ]+\.$/i', $lipsum->sentence());
     }
 
     public function testSentences()
     {
-        $this->assertRegExp('/^[a-z, ]+\. [a-z, ]+\. [a-z, ]+\.$/i', $this->lipsum->sentences(3));
+        $lipsum = new joshtronic\LoremIpsum();
+        $this->assertRegExp(
+            '/^[a-z, ]+\. [a-z, ]+\. [a-z, ]+\.$/i',
+            $lipsum->sentences(3)
+        );
     }
 
     public function testSentencesArray()
     {
-        $sentences = $this->lipsum->sentencesArray(3);
+        $lipsum = new joshtronic\LoremIpsum();
+        $sentences = $lipsum->sentencesArray(3);
         $this->assertTrue(is_array($sentences));
         $this->assertCount(3, $sentences);
 
@@ -70,20 +72,23 @@ class LoremIpsumTest extends PHPUnit_Framework_TestCase
 
     public function testParagraph()
     {
-        $this->assertRegExp('/^([a-z, ]+\.)+$/i', $this->lipsum->paragraph());
+        $lipsum = new joshtronic\LoremIpsum();
+        $this->assertRegExp('/^([a-z, ]+\.)+$/i', $lipsum->paragraph());
     }
 
     public function testParagraphs()
     {
+        $lipsum = new joshtronic\LoremIpsum();
         $this->assertRegExp(
             '/^([a-z, ]+\.)+\n\n([a-z, ]+\.)+\n\n([a-z, ]+\.)+$/i',
-            $this->lipsum->paragraphs(3)
+            $lipsum->paragraphs(3)
         );
     }
 
     public function testParagraphsArray()
     {
-        $paragraphs = $this->lipsum->paragraphsArray(3);
+        $lipsum = new joshtronic\LoremIpsum();
+        $paragraphs = $lipsum->paragraphsArray(3);
         $this->assertTrue(is_array($paragraphs));
         $this->assertCount(3, $paragraphs);
 
@@ -94,31 +99,35 @@ class LoremIpsumTest extends PHPUnit_Framework_TestCase
 
     public function testMarkupString()
     {
+        $lipsum = new joshtronic\LoremIpsum();
         $this->assertRegExp(
             '/^<li>[a-z]+<\/li>$/i',
-            $this->lipsum->word('li')
+            $lipsum->word('li')
         );
     }
 
     public function testMarkupArray()
     {
+        $lipsum = new joshtronic\LoremIpsum();
         $this->assertRegExp(
             '/^<div><p>[a-z]+<\/p><\/div>$/i',
-            $this->lipsum->word(array('div', 'p'))
+            $lipsum->word(array('div', 'p'))
         );
     }
 
     public function testMarkupBackReference()
     {
+        $lipsum = new joshtronic\LoremIpsum();
         $this->assertRegExp(
             '/^<li><a href="[a-z]+">[a-z]+<\/a><\/li>$/i',
-            $this->lipsum->word('<li><a href="$1">$1</a></li>')
+            $lipsum->word('<li><a href="$1">$1</a></li>')
         );
     }
 
     public function testMarkupArrayReturn()
     {
-        $words = $this->lipsum->wordsArray(3, 'li');
+        $lipsum = new joshtronic\LoremIpsum();
+        $words = $lipsum->wordsArray(3, 'li');
         $this->assertTrue(is_array($words));
         $this->assertCount(3, $words);
 


### PR DESCRIPTION
* Updated to test again PHP 7.4 and to use that for coverage reporting.
* Added PHP nightly builds as an allowable failure.
* Added a git ignore as well as a `phpunit` configuration.
* Updated the tests and CI configuration to better handle the juggling of PHP and `phpunit` versions.
* Updated the coveralls dependency to be the latest and greatest instead of the deprecated package.
* Tweaked the README, updated the LICENSE years and bumped this package's version.
* Dropped Patreon link in favor of using Github Sponsors.