### PR TITLE
Fix #7 Change visibility of $words

### DIFF
--- a/src/LoremIpsum.php
+++ b/src/LoremIpsum.php
@@ -37,7 +37,7 @@ class LoremIpsum
      * @access private
      * @var    array
      */
-    public $words = array(
+    private $words = array(
         // Lorem ipsum...
         'lorem', 'ipsum', 'dolor', 'sit', 'amet', 'consectetur', 'adipiscing', 'elit',
 


### PR DESCRIPTION
The PHPDoc block of `$words` say that the visibility / access of `$words` is private but its `public` in php code.
https://github.com/joshtronic/php-loremipsum/blob/master/src/LoremIpsum.php#L37-L40