### PR TITLE
feat: ensure passed tags are strings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0']
+        php-version: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -23,7 +23,7 @@ jobs:
     - name: Run Tests
       run: vendor/bin/phpunit --coverage-clover ./coverage.xml
     - name: Upload Coverage
-      if: ${{ matrix.php-version == '7.4' }}
+      if: ${{ matrix.php-version == '8.1' }}
       uses: codecov/codecov-action@v1
       with:
         file: ./coverage.xml

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2014, 2015, 2016, 2017, 2018, 2019, 2020 Josh Sherman
+Copyright (c) 2014-2022 Josh Sherman
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "joshtronic/php-loremipsum",
   "description": "Lorem ipsum generator in PHP without dependencies",
-  "version": "1.0.6",
+  "version": "2.0.0",
   "type": "library",
   "keywords": [
     "lorem",

--- a/src/LoremIpsum.php
+++ b/src/LoremIpsum.php
@@ -9,7 +9,7 @@
  * Redistribution of these files must retain the above copyright notice.
  *
  * @author    Josh Sherman <hello@joshtronic.com>
- * @copyright Copyright 2014, 2015, 2016, 2017, 2018, 2019, 2020 Josh Sherman
+ * @copyright Copyright 2014-2022 Josh Sherman
  * @license   http://www.opensource.org/licenses/mit-license.html
  * @link      https://github.com/joshtronic/php-loremipsum
  */
@@ -351,11 +351,13 @@ class LoremIpsum
 
             foreach ($strings as $key => $string) {
                 foreach ($tags as $tag) {
-                    // Detects / applies back reference
-                    if ($tag[0] == '<') {
-                        $string = str_replace('$1', $string, $tag);
-                    } else {
-                        $string = sprintf('<%1$s>%2$s</%1$s>', $tag, $string);
+                    if (is_string($tag)) {
+                        // Detects / applies back reference
+                        if ($tag[0] == '<') {
+                            $string = str_replace('$1', $string, $tag);
+                        } else {
+                            $string = sprintf('<%1$s>%2$s</%1$s>', $tag, $string);
+                        }
                     }
 
                     $strings[$key] = $string;

--- a/tests/LoremIpsumTest.php
+++ b/tests/LoremIpsumTest.php
@@ -183,5 +183,16 @@ class LoremIpsumTest extends TestCase
             $this->$assertRegExp('/^<li>[a-z]+<\/li>$/i', $word);
         }
     }
+
+    /**
+     * @depends testAssertRegExp
+     */
+    public function testSkipNonStringTag($assertRegExp)
+    {
+        $lipsum = new LoremIpsum();
+        $this->$assertRegExp('/^[a-z]+$/i', $lipsum->word(123));
+        $this->$assertRegExp('/^[a-z]+$/i', $lipsum->word(array(1, 2, 3)));
+        $this->$assertRegExp('/^[a-z]+$/i', $lipsum->word(true));
+    }
 }
 


### PR DESCRIPTION
Newer versions of PHP raise a warning if you attempt to use array syntax
against non-strings / non-arrays. Added sanity check to ensure we're
working with a string, otherwise skip it.

Also added in PHP 8.1 to the testing suite and bumped the copyright.

Bumped version to 2.0 since as the change in expected output is a
breaking change.