### PR TITLE
PHP 8.1: Implicit incompatible float to int conversion is deprecated

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
     "php": ">=5.3"
   },
   "require-dev": {
-    "phpunit/phpunit": "^4.8.36 || ^9.0"
+    "phpunit/phpunit": "^4.8.36 || ^9.0",
+    "phpstan/phpstan": "^1.3"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -1,35 +1,34 @@
 {
-  "name": "joshtronic/php-loremipsum",
-  "description": "Lorem ipsum generator in PHP without dependencies",
-  "version": "2.0.0",
-  "type": "library",
-  "keywords": [
-    "lorem",
-    "ipsum",
-    "generator"
-  ],
-  "homepage": "https://github.com/joshtronic/php-loremipsum",
-  "license": "MIT",
-  "authors": [{
-    "name": "Josh Sherman",
-    "email": "hello@joshtronic.com",
-    "homepage": "https://joshtronic.com"
-  }],
-  "require": {
-    "php": ">=5.3"
-  },
-  "require-dev": {
-    "phpunit/phpunit": "^4.8.36 || ^9.0",
-    "phpstan/phpstan": "^1.3"
-  },
-  "autoload": {
-    "psr-4": {
-      "joshtronic\\": "src/"
-    }
-  },
-  "autoload-dev": {
-    "psr-4": {
-      "joshtronic\\Tests\\": "tests/"
+    "name": "joshtronic/php-loremipsum",
+    "description": "Lorem ipsum generator in PHP without dependencies",
+    "version": "2.0.0",
+    "type": "library",
+    "keywords": [
+      "lorem",
+      "ipsum",
+      "generator"
+    ],
+    "homepage": "https://github.com/joshtronic/php-loremipsum",
+    "license": "MIT",
+    "authors": [{
+      "name": "Josh Sherman",
+      "email": "hello@joshtronic.com",
+      "homepage": "https://joshtronic.com"
+    }],
+    "require": {
+      "php": ">=5.3"
+    },
+    "require-dev": {
+      "phpunit/phpunit": "^4.8.36 || ^9.0"
+    },
+    "autoload": {
+      "psr-4": {
+        "joshtronic\\": "src/"
+      }
+    },
+    "autoload-dev": {
+      "psr-4": {
+        "joshtronic\\Tests\\": "tests/"
+      }
     }
   }
-}

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,14 @@
+parameters:
+
+    paths:
+        - src
+
+    # The level 8 is the highest level
+    level: max
+
+    excludePaths:
+        - ./*/*/FileToBeExcluded.php
+
+    checkMissingIterableValueType: true
+
+    #editorUrl: 'vscode://file/%%file%%:%%line%%'

--- a/src/LoremIpsum.php
+++ b/src/LoremIpsum.php
@@ -24,7 +24,7 @@ class LoremIpsum
      * Whether or not we should be starting the string with "Lorem ipsum..."
      *
      * @access private
-     * @var    boolean
+     * @var    mixed
      */
     private $first = true;
 
@@ -35,7 +35,7 @@ class LoremIpsum
      * a complete list exists and if so, where to get it.
      *
      * @access private
-     * @var    array
+     * @var    array<string>
      */
     private $words = array(
         // Lorem ipsum...
@@ -83,7 +83,7 @@ class LoremIpsum
      */
     public function word($tags = false)
     {
-        return $this->words(1, $tags);
+        return strval($this->words(1, $tags));
     }
 
     /**
@@ -94,7 +94,7 @@ class LoremIpsum
      * @access public
      * @param  integer $count how many words to generate
      * @param  mixed   $tags string or array of HTML tags to wrap output with
-     * @return array   generated lorem ipsum words
+     * @return mixed  generated lorem ipsum words
      */
     public function wordsArray($count = 1, $tags = false)
     {
@@ -152,7 +152,7 @@ class LoremIpsum
      */
     public function sentence($tags = false)
     {
-        return $this->sentences(1, $tags);
+        return strval($this->sentences(1, $tags));
     }
 
     /**
@@ -163,7 +163,7 @@ class LoremIpsum
      * @access public
      * @param  integer $count how many sentences to generate
      * @param  mixed   $tags string or array of HTML tags to wrap output with
-     * @return array   generated lorem ipsum sentences
+     * @return mixed   generated lorem ipsum sentences
      */
     public function sentencesArray($count = 1, $tags = false)
     {
@@ -205,7 +205,7 @@ class LoremIpsum
      */
     public function paragraph($tags = false)
     {
-        return $this->paragraphs(1, $tags);
+        return strval($this->paragraphs(1, $tags));
     }
 
     /**
@@ -216,15 +216,18 @@ class LoremIpsum
      * @access public
      * @param  integer $count how many paragraphs to generate
      * @param  mixed   $tags string or array of HTML tags to wrap output with
-     * @return array   generated lorem ipsum paragraphs
+     * @return array<string>   generated lorem ipsum paragraphs
      */
     public function paragraphsArray($count = 1, $tags = false)
     {
+        // The $array parameter set to true means an array is returned.
+        // Return type is mixed, we should probably cast to array.
+        // @phpstan-ignore-next-line
         return $this->paragraphs($count, $tags, true);
     }
 
     /**
-     * Paragraphss
+     * Paragraphs
      *
      * Generates paragraphs of lorem ipsum.
      *
@@ -239,10 +242,13 @@ class LoremIpsum
         $paragraphs = array();
 
         for ($i = 0; $i < $count; $i++) {
-            $paragraphs[] = $this->sentences($this->gauss(5.8, 1.93));
+            $paragraphs[] = strval($this->sentences($this->gauss(5.8, 1.93)));
         }
 
-        return $this->output($paragraphs, $tags, $array, "\n\n");
+        if ($array) {
+            return $this->output($paragraphs, $tags, $array, "\n\n");
+        }
+        return strval($this->output($paragraphs, $tags, false, "\n\n"));
     }
 
     /**
@@ -256,7 +262,7 @@ class LoremIpsum
      * @access private
      * @param  double  $mean average value
      * @param  double  $std_dev stadnard deviation
-     * @return double  calculated distribution
+     * @return int  calculated distribution
      */
     private function gauss($mean, $std_dev)
     {
@@ -264,7 +270,7 @@ class LoremIpsum
         $y = mt_rand() / mt_getrandmax();
         $z = sqrt(-2 * log($x)) * cos(2 * pi() * $y);
 
-        return $z * $std_dev + $mean;
+        return intval($z * $std_dev + $mean);
     }
 
     /**
@@ -274,6 +280,7 @@ class LoremIpsum
      * the first time we are generating the text.
      *
      * @access private
+     * @return void
      */
     private function shuffle()
     {
@@ -299,18 +306,19 @@ class LoremIpsum
      * first word of the sentence.
      *
      * @access private
-     * @param  array   $sentences the sentences we would like to punctuate
+     * @param  array<string>   $sentences the sentences we would like to punctuate
+     * @return void
      */
     private function punctuate(&$sentences)
     {
         foreach ($sentences as $key => $sentence) {
-            $words = count($sentence);
+            $words = count($sentences);
 
             // Only worry about commas on sentences longer than 4 words
             if ($words > 4) {
                 $mean    = log($words, 6);
                 $std_dev = $mean / 6;
-                $commas  = round($this->gauss($mean, $std_dev));
+                $commas  = $this->gauss($mean, $std_dev);
 
                 for ($i = 1; $i <= $commas; $i++) {
                     $word = round($i * $words / ($commas + 1));
@@ -334,7 +342,7 @@ class LoremIpsum
      * into a string or not.
      *
      * @access private
-     * @param  array   $strings an array of generated strings
+     * @param  array<string>   $strings an array of generated strings
      * @param  mixed   $tags string or array of HTML tags to wrap output with
      * @param  boolean $array whether an array or a string should be returned
      * @param  string  $delimiter the string to use when calling implode()
@@ -373,4 +381,3 @@ class LoremIpsum
         return $strings;
     }
 }
-

--- a/src/LoremIpsum.php
+++ b/src/LoremIpsum.php
@@ -312,8 +312,7 @@ class LoremIpsum
     private function punctuate(&$sentences)
     {
         foreach ($sentences as $key => $sentence) {
-            $words = count($sentences);
-
+            $words = count($sentence);
             // Only worry about commas on sentences longer than 4 words
             if ($words > 4) {
                 $mean    = log($words, 6);

--- a/src/LoremIpsum.php
+++ b/src/LoremIpsum.php
@@ -114,6 +114,7 @@ class LoremIpsum
      */
     public function words($count = 1, $tags = false, $array = false)
     {
+        $count      = (int) $count;
         $words      = array();
         $word_count = 0;
 


### PR DESCRIPTION
In PHP 8.1 floats are not implicitly converted to integers as before. 
The array_slice on line 139 requires an integer as the third parameter (the $count variable) so added line 117 to do the conversion of $count.